### PR TITLE
Add typings to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,5 +20,6 @@
     "LICENSE.md",
     "tracker.js",
     "tracker.d.ts"
-  ]
+  ],
+  "typings": "tracker.d.ts"
 }


### PR DESCRIPTION
This seems to be required for the typings to import automatically.