### PR TITLE
Corrected type of possibly undefined fields

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -212,15 +212,15 @@ export interface TrackJSErrorPayload {
     /** Timestamp the request started */
     startedOn: ISO8601DateString;
     /** Timestamp the request completed */
-    completedOn: ISO8601DateString;
+    completedOn?: ISO8601DateString;
     /** HTTP Method used */
     method: string;
     /** URL Requested */
     url: string;
     /** HTTP Status Code */
-    statusCode: number;
+    statusCode?: number;
     /** HTTP Status Text */
-    statusText: string;
+    statusText?: string;
     /** Mechanism of network use. IE "fetch", "xhr" */
     type: string;
   }[];


### PR DESCRIPTION
`completedOn`, `statusCode`, and `statusText` aren't always present, particularly on network requests that are aborted with an AbortController.